### PR TITLE
updating and backporting

### DIFF
--- a/eseries/__init__.py
+++ b/eseries/__init__.py
@@ -1,3 +1,9 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
 from .eseries import (ESeries, E3, E6, E12, E24, E48, E96, E192, series, series_keys, tolerance,
                       find_greater_than_or_equal, find_greater_than, find_less_than_or_equal, find_less_than,
                       find_nearest, find_nearest_few, erange, open_erange)

--- a/eseries/cli.py
+++ b/eseries/cli.py
@@ -28,7 +28,7 @@ See '{program} help <command>' for help on specific commands.
 
 
 @dsc.command()
-def handle_nearest(args):
+def handle_nearest(precommand, args):
     """usage: {program} nearest <e-series> <value> [--symbol]
 
     The nearest value in an E-Series.
@@ -45,7 +45,7 @@ def handle_nearest(args):
 
 
 @dsc.command()
-def handle_nearby(args):
+def handle_nearby(precommand, args):
     """usage: {program} nearby <e-series> <value> [--symbol]
 
     At least three nearby values in an E-Series, and least one of
@@ -65,7 +65,7 @@ def handle_nearby(args):
 
 
 @dsc.command()
-def handle_gt(args):
+def handle_gt(precommand, args):
     """usage: {program} gt <e-series> <value> [--symbol]
 
     The largest value greater-than the given value.
@@ -82,7 +82,7 @@ def handle_gt(args):
 
 
 @dsc.command()
-def handle_ge(args):
+def handle_ge(precommand, args):
     """usage: {program} ge <e-series> <value> [--symbol]
 
     The largest value greater-than or equal-to the given value.
@@ -99,7 +99,7 @@ def handle_ge(args):
 
 
 @dsc.command()
-def handle_lt(args):
+def handle_lt(precommand, args):
     """usage: {program} lt <e-series> <value> [--symbol]
 
     The largest value less-than the given value.
@@ -116,7 +116,7 @@ def handle_lt(args):
 
 
 @dsc.command()
-def handle_le(args):
+def handle_le(precommand, args):
     """usage: {program} le <e-series> <value> [--symbol]
 
     The largest value less-than or equal-to the given value.
@@ -133,7 +133,7 @@ def handle_le(args):
 
 
 @dsc.command()
-def handle_tolerance(args):
+def handle_tolerance(precommand, args):
     """usage: {program} tolerance <e-series> [--symbol]
 
     The tolerance of the given E-Series.
@@ -153,7 +153,7 @@ def handle_tolerance(args):
     return os.EX_OK
 
 @dsc.command()
-def handle_series(args):
+def handle_series(precommand, args):
     """usage: {program} series <e-series>
 
     The base values for the given E-Series.
@@ -165,7 +165,7 @@ def handle_series(args):
 
 
 @dsc.command()
-def handle_range(args):
+def handle_range(precommand, args):
     """usage: {program} range <e-series> <start-value> <stop-value> [--symbol]
 
     All values in the given E-series from start-value to stop-value inclusive.
@@ -184,7 +184,7 @@ def handle_range(args):
 
 
 @dsc.command()
-def handle_lower_tolerance_limit(args):
+def handle_lower_tolerance_limit(precommand, args):
     """usage: {program} lower-tolerance-limit <e-series> <value> [--symbol]
 
     The lower tolerance limit of a nominal value given the tolerance
@@ -202,7 +202,7 @@ def handle_lower_tolerance_limit(args):
 
 
 @dsc.command()
-def handle_upper_tolerance_limit(args):
+def handle_upper_tolerance_limit(precommand, args):
     """usage: {program} upper-tolerance-limit <e-series> <value> [--symbol]
 
     The upper tolerance limit of a nominal value given the tolerance
@@ -220,7 +220,7 @@ def handle_upper_tolerance_limit(args):
 
 
 @dsc.command()
-def handle_tolerance_limits(args):
+def handle_tolerance_limits(precommand, args):
     """usage: {program} tolerance-limits <e-series> <value> [--symbol]
 
     The upper and lower tolerance limits of a nominal value given the
@@ -263,11 +263,10 @@ def main(argv=None):
     try:
         return dsc.main(
             program='eseries',
-            version='E-Series {}'.format(__version__),
             argv=argv,
             doc_template=DOC_TEMPLATE,
             exit_at_end=False)
-    except docopt.DocoptExit as exc:
+    except (docopt.DocoptExit, SystemExit) as exc:
         print(exc, file=sys.stderr)
         return os.EX_USAGE
     except ValueError as exc:

--- a/eseries/cli.py
+++ b/eseries/cli.py
@@ -1,5 +1,12 @@
 """The command-line for eseries"""
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import unicode_literals
 
+from builtins import int
+from future import standard_library
+standard_library.install_aliases()
 import os
 import sys
 
@@ -244,7 +251,7 @@ def present_value(args, nearest):
 
 
 def extract_series_key(args):
-    e_series_name = args['<e-series>']
+    e_series_name = args['<e-series>'].upper()
     series_key = series_key_from_name(e_series_name)
     return series_key
 

--- a/eseries/eng.py
+++ b/eseries/eng.py
@@ -1,8 +1,16 @@
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+from builtins import str
+from builtins import int
+from future import standard_library
+standard_library.install_aliases()
 from math import floor, log10
 
 from eseries.eseries import _round_sig
 
-PREFIXES = 'yzafpnµm kMGTPEZY'
+PREFIXES = 'yzafpnum kMGTPEZY'
 
 
 def eng_string(x, sig_figs=3, prefix=True):

--- a/eseries/eseries.py
+++ b/eseries/eseries.py
@@ -1,3 +1,15 @@
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+from builtins import int
+# from builtins import round
+from builtins import range
+from builtins import map
+from builtins import zip
+from builtins import str
+from future import standard_library
+standard_library.install_aliases()
 from bisect import bisect_right, bisect_left
 from collections import OrderedDict
 from enum import IntEnum
@@ -298,9 +310,9 @@ def erange(series_key, start, stop):
         ValueError: If start or stop are not both finite.
         ValueError: If start or stop are out of range.
     """
-    if not math.isfinite(start):
+    if math.isinf(start):
         raise ValueError("Start value {} is not finite".format(start))
-    if not math.isfinite(stop):
+    if math.isinf(stop):
         raise ValueError("Stop value {} is not finite".format(stop))
     if start < _MINIMUM_E_VALUE:
         raise ValueError("{} is too small. The start value must greater than or equal to {}".format(stop, _MINIMUM_E_VALUE))
@@ -358,9 +370,9 @@ def open_erange(series_key, start, stop):
         ValueError: If start or stop are not both finite.
         ValueError: If start or stop are out of range.
     """
-    if not math.isfinite(start):
+    if math.isinf(start):
         raise ValueError("Start value {} is not finite".format(start))
-    if not math.isfinite(stop):
+    if math.isinf(stop):
         raise ValueError("Stop value {} is not finite".format(stop))
     if start < _MINIMUM_E_VALUE:
         raise ValueError("{} is too small. The start value must greater than or equal to {}".format(stop, _MINIMUM_E_VALUE))
@@ -434,7 +446,7 @@ def _nearest_n(candidates, value, n):
 
 
 def _round_sig(x, figures=6):
-    return 0 if x == 0 else round(x, figures - floor(log10(abs(x))) - 1)
+    return 0 if x == 0 else round(x, int(figures - floor(log10(abs(x))) - 1))
 
 
 def _decade_mantissa(value):

--- a/setup.py
+++ b/setup.py
@@ -69,10 +69,14 @@ setup(
 
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 3 :: Only',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 
     # What does your project relate to?
@@ -86,7 +90,7 @@ setup(
     # project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['docopt_subcommands'],
+    install_requires=['docopt_subcommands>=4.0', 'future'],
 
     # List additional groups of dependencies here (e.g. development dependencies).
     # You can install these using the following syntax, for example:

--- a/test/test_eseries.py
+++ b/test/test_eseries.py
@@ -17,7 +17,7 @@ def test_series_cardinality(series_key):
        low=floats(min_value=1e-35, max_value=1e35, allow_nan=False, allow_infinity=False))
 def test_erange_cardinality_over_one_order_of_magnitude(series_key, low):
     high = low * 10.0
-    assume(math.isfinite(high))
+    assume(not math.isinf(high))
     values = list(erange(series_key, low, high))
     include_end = bool(high in values)
     cardinality = series_key + include_end
@@ -28,7 +28,7 @@ def test_erange_cardinality_over_one_order_of_magnitude(series_key, low):
        low=floats(min_value=1e-35, max_value=1e35, allow_nan=False, allow_infinity=False))
 def test_open_erange_cardinality_over_one_order_of_magnitude(series_key, low):
     high = low * 10.0
-    assume(math.isfinite(high))
+    assume(not math.isinf(high))
     values = list(open_erange(series_key, low, high))
     cardinality = series_key
     assert len(values) == cardinality

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+[tox]
+envlist = py{27,35,36,37,38,39}
+
+[travis]
+python =
+    2.7: py27
+    3.5: py35
+    3.6: py36
+    3.7: py37
+    3.8: py38
+    3.9: py39
+
+[testenv]
+passenv = *
+deps =
+    pytest
+    hypothesis
+changedir = test
+commands =
+    py{27,35,36,37,38,39}: pip install -e {toxinidir}
+    pytest


### PR DESCRIPTION
Updated eseries to work with docopt-subcommands 4.0.0 and backported so it also works with Python 2.7. Added tox testing for testing with multiple versions of Python. eseries passes tests on Python 2.7, 3.5 - 3.9.