### PR TITLE
add compatability to python 3.12

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -4,10 +4,10 @@ on: push
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ The ``eseries`` package is available on the Python Package Index (PyPI):
 .. image:: https://badge.fury.io/py/eseries.svg
     :target: https://badge.fury.io/py/eseries
 
-The package supports Python 3 only. To install::
+The package supports Python 3 and is compatible to Python 2.7. To install::
 
   $ pip install eseries
 
@@ -151,7 +151,7 @@ Testing
 Testing is performed for all supported versions using ``tox``. You'll need to ensure that the required
 Python versions are available in your environment. For example, if you're using ``pyenv``, do::
 
-  $ pyenv local 2.7.18 3.6.12 3.7.9 3.8.1 3.9.1
+  $ pyenv local 2.7 3.6 3.7 3.8 3.9 3.10 3.11 3.12
 
 before running ``tox``::
 

--- a/eseries/__init__.py
+++ b/eseries/__init__.py
@@ -2,8 +2,11 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from future import standard_library
-standard_library.install_aliases()
+try:
+    from future import standard_library
+    standard_library.install_aliases()
+except ImportError:
+    pass
 from .eseries import (ESeries, E3, E6, E12, E24, E48, E96, E192, series, series_keys, series_key_from_name, tolerance,
                       find_greater_than_or_equal, find_greater_than, find_less_than_or_equal, find_less_than,
                       find_nearest, find_nearest_few, erange, open_erange)

--- a/eseries/cli.py
+++ b/eseries/cli.py
@@ -5,8 +5,11 @@ from __future__ import division
 from __future__ import unicode_literals
 
 from builtins import int
-from future import standard_library
-standard_library.install_aliases()
+try:
+    from future import standard_library
+    standard_library.install_aliases()
+except ImportError:
+    pass
 import os
 import sys
 

--- a/eseries/eng.py
+++ b/eseries/eng.py
@@ -4,8 +4,11 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from builtins import str
 from builtins import int
-from future import standard_library
-standard_library.install_aliases()
+try:
+    from future import standard_library
+    standard_library.install_aliases()
+except ImportError:
+    pass
 from math import floor, log10
 
 from eseries.eseries import _round_sig

--- a/eseries/eseries.py
+++ b/eseries/eseries.py
@@ -8,8 +8,11 @@ from builtins import range
 from builtins import map
 from builtins import zip
 from builtins import str
-from future import standard_library
-standard_library.install_aliases()
+try:
+    from future import standard_library
+    standard_library.install_aliases()
+except ImportError:
+    pass
 from bisect import bisect_right, bisect_left
 from collections import OrderedDict
 from enum import IntEnum

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,9 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
 
     # What does your project relate to?

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{2.7,3.6,3.7,3.8,3.9}
+envlist = py{2.7,3.6,3.7,3.8,3.9,3.10,3.11,3.12}
 
 [testenv]
 passenv = *
@@ -8,5 +8,5 @@ deps =
     hypothesis
 changedir = test
 commands =
-    py{2.7,3.6,3.7,3.8,3.9}: pip install -e {toxinidir}
+    py{2.7,3.6,3.7,3.8,3.9,3.10,3.11,3.12}: pip install -e {toxinidir}
     pytest


### PR DESCRIPTION
* put backwards compatability to python 2.7 in a try/except block
* dropped testing of python2.7 (github actions dropped support completly)
* will close issue #5 